### PR TITLE
Refactor: 액티비티 파트를 리팩토링 진행

### DIFF
--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -33,10 +33,11 @@ public class ActivityController {
         return activityService.update(id, activityRequest);
     }
 
-    @PostMapping("/image")
-    public String uploadImage(@RequestParam("multipartFile") MultipartFile multipartFile)
+    @PostMapping("/{id}/images")
+    public String uploadImage(@PathVariable("id") Integer id,
+        @RequestParam("multipartFile") MultipartFile multipartFile)
         throws IOException {
-        return activityService.uploadImage(multipartFile);
+        return activityService.uploadImage(multipartFile, id);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -33,11 +33,10 @@ public class ActivityController {
         return activityService.update(id, activityRequest);
     }
 
-    @PostMapping("/{id}/images")
-    public String uploadImage(@PathVariable("id") Integer id,
-        @RequestParam("multipartFile") MultipartFile multipartFile)
+    @PostMapping("/images")
+    public String uploadImage(@RequestParam("multipartFile") MultipartFile multipartFile)
         throws IOException {
-        return activityService.uploadImage(multipartFile, id);
+        return activityService.uploadImage(multipartFile);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -39,6 +39,9 @@ public class Activity {
     @OrderBy("createdAt DESC")
     private Set<UserActivity> userActivities = new HashSet<>();
 
+    private static final String DEFAULT_IMAGE_URL =
+        "https://walkerholic-with-you.s3.ap-northeast-2.amazonaws.com/globe-asia-solid.svg";
+
     public Activity() {
     }
 
@@ -61,7 +64,7 @@ public class Activity {
     }
 
     public void changeImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+        this.imageUrl = (imageUrl == null ? DEFAULT_IMAGE_URL : imageUrl);
     }
 
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import javax.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
 
 @Entity
 @Table(name = "activity")
@@ -55,7 +56,7 @@ public class Activity {
         this.name = requestActivity.name;
         this.description = requestActivity.description;
         this.score = requestActivity.score;
-
+        this.imageUrl = requestActivity.imageUrl;
         return this;
     }
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -1,8 +1,10 @@
 package com.yunhalee.walkerholic.activity.domain;
 
 import com.yunhalee.walkerholic.useractivity.domain.UserActivity;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 
 import javax.persistence.*;
@@ -39,13 +41,9 @@ public class Activity {
     public Activity() {
     }
 
-    public Activity(String name, Integer score, String description) {
-        this.name = name;
-        this.score = score;
-        this.description = description;
-    }
-
-    public Activity(String name, Integer score, String description, String imageUrl) {
+    @Builder
+    public Activity(@NonNull String name, @NonNull Integer score, @NonNull String description,
+        String imageUrl) {
         this.name = name;
         this.score = score;
         this.description = description;
@@ -57,15 +55,12 @@ public class Activity {
         this.name = requestActivity.name;
         this.description = requestActivity.description;
         this.score = requestActivity.score;
-        this.imageUrl = requestActivity.imageUrl;
 
         return this;
     }
 
-    public void setDefaultImageUrl(String imageUrl, String defaultImageUrl) {
-        if (imageUrl == null || imageUrl.isEmpty() || imageUrl.isBlank()) {
-            this.imageUrl = defaultImageUrl;
-        }
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -5,10 +5,8 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class ActivityRequest {
 
     @NotNull

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -20,19 +20,23 @@ public class ActivityRequest {
     @NotNull
     private String description;
 
+    private String imageUrl;
+
     @Builder
     public ActivityRequest(@NonNull String name, @NonNull Integer score,
-        @NonNull String description) {
+        @NonNull String description, String imageUrl) {
         this.name = name;
         this.score = score;
         this.description = description;
+        this.imageUrl = imageUrl;
     }
 
     public Activity toActivity() {
         return Activity.builder()
             .name(name)
             .score(score)
-            .description(description).build();
+            .description(description)
+            .imageUrl(imageUrl).build();
     }
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -4,6 +4,7 @@ import com.yunhalee.walkerholic.activity.domain.Activity;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Getter
@@ -19,18 +20,19 @@ public class ActivityRequest {
     @NotNull
     private String description;
 
-    private String imageUrl;
-
     @Builder
-    public ActivityRequest(String name, Integer score, String description, String imageUrl) {
+    public ActivityRequest(@NonNull String name, @NonNull Integer score,
+        @NonNull String description) {
         this.name = name;
         this.score = score;
         this.description = description;
-        this.imageUrl = imageUrl;
     }
 
     public Activity toActivity() {
-        return new Activity(name, score, description, imageUrl);
+        return Activity.builder()
+            .name(name)
+            .score(score)
+            .description(description).build();
     }
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
@@ -2,10 +2,8 @@ package com.yunhalee.walkerholic.activity.dto;
 
 import com.yunhalee.walkerholic.activity.domain.Activity;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class ActivityResponse {
 
     private Integer id;

--- a/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
@@ -9,7 +9,6 @@ import com.yunhalee.walkerholic.activity.domain.Activity;
 import com.yunhalee.walkerholic.activity.domain.ActivityRepository;
 import java.io.IOException;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,9 +25,6 @@ public class ActivityService {
 
     private static final String UPLOAD_DIR = "activity-uploads";
 
-    @Value("${AWS_S3_BASE_IMAGE_URL}")
-    private String defaultImageUrl;
-
     public ActivityService(
         ActivityRepository activityRepository, S3ImageUploader s3ImageUploader) {
         this.activityRepository = activityRepository;
@@ -37,9 +33,7 @@ public class ActivityService {
 
     public ActivityResponse create(ActivityRequest activityRequest) {
         Activity activity = activityRequest.toActivity();
-        activity.changeImageUrl(
-            activityRequest.getImageUrl() == null ?
-                defaultImageUrl : activityRequest.getImageUrl());
+        activity.changeImageUrl(activityRequest.getImageUrl());
         activityRepository.save(activity);
         return new ActivityResponse(activity);
     }

--- a/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
@@ -34,6 +34,9 @@ public class S3ImageUploader {
     @Value("${AWS_S3_BASE_IMAGE_URL}")
     private String defaultImageUrl;
 
+    @Value("${AWS_S3_BUCKET_URL}")
+    private String bucketUrl;
+
     private AmazonS3 s3;
 
     public S3ImageUploader(AmazonS3 s3) {
@@ -54,6 +57,13 @@ public class S3ImageUploader {
             new IOException("Could not save file : " + multipartFile.getOriginalFilename());
         }
         return "";
+    }
+
+    public void deleteOriginalImage(String originalImageUrl, String changedImageUrl) {
+        if (!originalImageUrl.equals(defaultImageUrl) ||
+            !originalImageUrl.equals(changedImageUrl)) {
+            deleteFile(originalImageUrl.replaceAll(bucketUrl, ""));
+        }
     }
 
     public List<String> listFolder(String folder) {

--- a/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
@@ -3,17 +3,14 @@ package com.yunhalee.walkerholic.common.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import java.util.Objects;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;

--- a/src/test/java/com/yunhalee/walkerholic/activity/domain/ActivityRepositoryTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/activity/domain/ActivityRepositoryTests.java
@@ -25,8 +25,10 @@ public class ActivityRepositoryTests {
     @Test
     public void createActivity() {
         //given
-        Activity activity = new Activity("Plogging90", 100,
-            "Picking up trash while jogging for more than 90minutes.");
+        Activity activity = Activity.builder()
+            .name("Plogging90")
+            .score(100)
+            .description("Picking up trash while jogging for more than 90minutes.").build();
 
         //when
         Activity activity1 = repo.save(activity);
@@ -40,7 +42,6 @@ public class ActivityRepositoryTests {
         //given
         Integer id = 1;
         Activity activity = repo.findById(id).get();
-
         activity.setScore(3);
 
         //when

--- a/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
@@ -32,9 +32,6 @@ public class ActivityServiceTests {
     @Autowired
     ActivityRepository activityRepository;
 
-    @Autowired
-    S3ImageUploader s3ImageUploader;
-
     @Value("${AWS_S3_BUCKET_URL}")
     private String bucketUrl;
 

--- a/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
@@ -48,8 +48,7 @@ public class ActivityServiceTests {
     private static final String DESCRIPTION = "This is test Activity.";
     private static final String IMAGE_URL = "http://testActivity/imageURL";
 
-    @BeforeEach
-    public void setUp() {
+    void setUp() {
         activityRequest = ActivityRequest.builder()
             .name(NAME)
             .score(SCORE)
@@ -62,6 +61,7 @@ public class ActivityServiceTests {
     @Test
     public void createActivity() {
         //given
+        setUp();
 
         //when
         ActivityResponse activityResponse = activityService.create(activityRequest);
@@ -78,6 +78,7 @@ public class ActivityServiceTests {
     @Test
     public void updateActivity() {
         //given
+        setUp();
         Integer id = 1;
         String originalName = activityRepository.findById(id).get().getName();
 

--- a/src/test/java/com/yunhalee/walkerholic/util/S3ImageUploaderTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/util/S3ImageUploaderTests.java
@@ -1,7 +1,9 @@
 package com.yunhalee.walkerholic.util;
 
+import com.yunhalee.walkerholic.activity.dto.ActivityRequest;
 import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +39,18 @@ public class S3ImageUploaderTests {
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
 
+    private static final String FOLDER_NAME = "testUploads";
+    private static final String ORIGINAL_FILE_NAME = "sampleFile.txt";
+    private MultipartFile multipartFile;
+
+    @BeforeEach
+    public void setUp() {
+        multipartFile = new MockMultipartFile("uploaded-file",
+            ORIGINAL_FILE_NAME,
+            "text/plain",
+            "This is the file content".getBytes()) {
+        };
+    }
 
     @Test
     public void testListFolder() {
@@ -60,15 +74,9 @@ public class S3ImageUploaderTests {
     @Test
     public void testUploadFile() throws IOException {
         //given
-        String folderName = "testUploads";
-        MultipartFile multipartFile = new MockMultipartFile("uploaded-file",
-            "sampleFile.txt",
-            "text/plain",
-            "This is the file content".getBytes()) {
-        };
 
         //when
-        String imageUrl = s3ImageUploader.uploadFile(folderName, multipartFile);
+        String imageUrl = s3ImageUploader.uploadFile(FOLDER_NAME, multipartFile);
 
         //then
         System.out.println(imageUrl);
@@ -78,39 +86,26 @@ public class S3ImageUploaderTests {
     @Test
     public void testDeleteFile() throws IOException {
         //given
-        String folderName = "testUploads";
-        MultipartFile multipartFile = new MockMultipartFile("uploaded-file",
-            "sampleFile.txt",
-            "text/plain",
-            "This is the file content".getBytes()) {
-        };
-        s3ImageUploader.uploadFile(folderName, multipartFile);
+        s3ImageUploader.uploadFile(FOLDER_NAME, multipartFile);
 
         //when
-        s3ImageUploader.deleteFile("testUploads/sampleFile.txt");
-        List<String> list = s3ImageUploader.listFolder(folderName);
+        s3ImageUploader.deleteFile(FOLDER_NAME + "/" + ORIGINAL_FILE_NAME);
+        List<String> list = s3ImageUploader.listFolder(FOLDER_NAME);
 
         //then
         for (String s : list) {
             System.out.println(s);
         }
-
     }
 
     @Test
     public void testDeleteFolder() throws IOException {
         //given
-        String folderName = "testUploads";
-        MultipartFile multipartFile = new MockMultipartFile("uploaded-file",
-            "sampleFile.txt",
-            "text/plain",
-            "This is the file content".getBytes()) {
-        };
-        s3ImageUploader.uploadFile(folderName, multipartFile);
+        s3ImageUploader.uploadFile(FOLDER_NAME, multipartFile);
 
         //when
-        s3ImageUploader.removeFolder(folderName);
-        List<String> list = s3ImageUploader.listFolder(folderName);
+        s3ImageUploader.removeFolder(FOLDER_NAME);
+        List<String> list = s3ImageUploader.listFolder(FOLDER_NAME);
 
         //then
         assertEquals(list.size(), 0);


### PR DESCRIPTION
이전 comment를 확인하고 코드를 변경하였습니다!

✔️ activityRequest와 activity에 builder를 이용하여 생성자가 중복되는 것을 방지하였습니다.
✔️ activityServiceTests에서는 builder를 사용하여 테스트를 진행하고 uploadImage테스트 코드를 추가로 작성하였습니다. 
✔️ activity create시에는 이미지 url을 디폴트 이미지로 설정하도록 하고 이미지 업로드가 필요한 경우에만 "activities/{id}/images"경로를 통하여 이미지 업로드및 이미지 url 업데이트가 가능하도록 하였습니다. 
✔️ 이때, 기존 이미지 삭제메서드는 기존 이미지가 디폴트 이미지와 경로가 동일하지 않을 때만 파일을 삭제하도록 하였습니다. 

그런데 혹시 create와 update 메서드를 uploadImage메서드와 분리하였을때, 각각의 메서드가 서로 다른 트랜잭션에서 이뤄지고있는데 하나의 액티비티를 대상으로 하는 create(create+uploadImage) 혹은  update(update + uploadImage) 기능들이 다른 트랜잭션에서 일어나도 괜찮은 걸까요? 😭